### PR TITLE
Update README.md

### DIFF
--- a/docs/00-initial-setup/README.md
+++ b/docs/00-initial-setup/README.md
@@ -273,7 +273,10 @@ To initialize your database:
 
 The code for the lambda functions resides within the path `aws-serverless-security-workshop/src/app`. The first thing you need to do is install node dependencies by navigating to this folder and using the following command: 
 	
-`cd src/app && npm install`
+```sh
+$ cd ~/environment/aws-serverless-security-workshop/src/app
+$ npm install
+```
 	
 > Note: If you see this warning
 > 


### PR DESCRIPTION
update the command and split into two commands

reason: if customers are not in the correct path, they may not cd into correct correctly hence fail to npm install correctly

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
