### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/src/template.yaml
+++ b/src/template.yaml
@@ -36,7 +36,7 @@ Resources:
     Properties:
       CodeUri: app/
       Handler: managePartners.lambda_handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Policies:
         - VPCAccessPolicy: {}
         - Version: '2012-10-17'
@@ -82,7 +82,7 @@ Resources:
     Properties:
       CodeUri: app/
       Handler: customizeUnicorn.lambda_handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Policies:
         - VPCAccessPolicy: {}
 #        - Version: '2012-10-17'
@@ -132,7 +132,7 @@ Resources:
     Properties:
       CodeUri: app/
       Handler: unicornParts.lambda_handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Policies:
         - VPCAccessPolicy: {}
 #        - Version: '2012-10-17'


### PR DESCRIPTION
CloudFormation templates in aws-serverless-security-workshop have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.