### PR TITLE
Correcting bug in Module 0 README

### DIFF
--- a/docs/00-initial-setup/README.md
+++ b/docs/00-initial-setup/README.md
@@ -457,7 +457,7 @@ In addition to the lambda code, the configurations for Lambda function and the R
 	To do it from commandline:
 
 	```
-	aws cloudformation describe-stacks --region $REGION --stack-name CustomizeUnicorns --query "Stacks[0].Outputs[0].OutputValue --output text"
+	aws cloudformation describe-stacks --region $REGION --stack-name CustomizeUnicorns --query "Stacks[0].Outputs[0].OutputValue" --output text
 	```
 
 	e.g.


### PR DESCRIPTION
Double-quote in the wrong location in a recent PR

*Issue #, if available:*

*Description of changes:*
Double-quote in the wrong location in a CLI example, introduced in PR #28 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
