### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/docs/01-add-authentication/README.md
+++ b/docs/01-add-authentication/README.md
@@ -173,7 +173,7 @@ We need to configure a [**Lambda authorizer**](https://docs.aws.amazon.com/apiga
 	    Type: AWS::Serverless::Function
 	    Properties:
 	      CodeUri: authorizer/
-	      Runtime: nodejs10.x
+	      Runtime: nodejs14.x
 	      Handler: index.handler
 	      Policies:
 	        Statement:

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -36,7 +36,7 @@ Resources:
     Properties:
       CodeUri: app/
       Handler: managePartners.lambda_handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - VPCAccessPolicy: {}
         - Version: '2012-10-17'
@@ -82,7 +82,7 @@ Resources:
     Properties:
       CodeUri: app/
       Handler: customizeUnicorn.lambda_handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - VPCAccessPolicy: {}
 #        - Version: '2012-10-17'
@@ -132,7 +132,7 @@ Resources:
     Properties:
       CodeUri: app/
       Handler: unicornParts.lambda_handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - VPCAccessPolicy: {}
 #        - Version: '2012-10-17'


### PR DESCRIPTION
CloudFormation templates in aws-serverless-security-workshop have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.