### PR TITLE
Allow node.js to use tls1.0 for db connection

### DIFF
--- a/src/template.yaml
+++ b/src/template.yaml
@@ -75,6 +75,7 @@ Resources:
         Variables:
           USER_POOL_ID: !Ref CognitoUserPool
           PARTNER_DDB_TABLE: !Ref PartnerDDBTable
+          NODE_OPTIONS: --tls-min-v1.0
 
 
   CustomizeUnicornFunction:
@@ -126,6 +127,9 @@ Resources:
             Method: delete
             RestApiId:
               Ref: UnicornApi
+      Environment:
+        Variables:
+          NODE_OPTIONS: --tls-min-v1.0
 
   UnicornPartsFunction:
     Type: AWS::Serverless::Function
@@ -176,6 +180,9 @@ Resources:
             Method: get
             RestApiId:
               Ref: UnicornApi
+      Environment:
+        Variables:
+          NODE_OPTIONS: --tls-min-v1.0
 
   UnicornApi:
     Type: AWS::Serverless::Api


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add node option to lower the minimum tls version to 1.0, which is required when running with a MySQL 5.6 DB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
