### PR TITLE
Allow node.js to use tls1.0 for db connection

### DIFF
--- a/src/template.yaml
+++ b/src/template.yaml
@@ -8,6 +8,7 @@ Globals:
     Environment:
       Variables:
         SECRET_NAME: secure-serverless-db-secret # name of the RDS credentials in secrets manager
+        NODE_OPTIONS: --tls-min-v1.0
 
 Parameters:
   InitResourceStack:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add node option to lower the minimum tls version to 1.0, which is required when running with a MySQL 5.6 DB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
