### PR TITLE
update Engine to aurora-mysql

### DIFF
--- a/src/init/init-template.yml
+++ b/src/init/init-template.yml
@@ -199,7 +199,7 @@ Resources:
     Type: AWS::RDS::DBInstance
     Properties:
       DBInstanceClass: db.t2.small
-      Engine: aurora
+      Engine: aurora-mysql
       DBClusterIdentifier: !Ref AuroraDBCluster
 
   AuroraDBCluster:
@@ -209,7 +209,7 @@ Resources:
     Properties:
       MasterUsername: admin
       MasterUserPassword: !Ref DbPassword
-      Engine: aurora
+      Engine: aurora-mysql
       DBSubnetGroupName: !Ref AuroraSubnetGroup
       VpcSecurityGroupIds:
         - !Ref AuroraSecurityGroup 


### PR DESCRIPTION
update Engine to aurora-mysql to fix module 4(TLS module is broken)

*Issue #, if available:*
Module 4 was broken

```
2022-07-06T14:52:41.340Z    76c8af12-3f92-43b0-bb53-22a5898746cc    ERROR    Error: 139998703617920:error:1425F102:SSL routines:ssl_choose_client_version:unsupported protocol:../deps/openssl/openssl/ssl/statem/statem_lib.c:1958:

   --------------------

 at Protocol._enqueue (/var/task/node_modules/mysql/lib/protocol/Protocol.js:144:48)
   at Protocol.handshake (/var/task/node_modules/mysql/lib/protocol/Protocol.js:51:23)
   at Connection.connect (/var/task/node_modules/mysql/lib/Connection.js:116:18)
   at Connection._implyConnect (/var/task/node_modules/mysql/lib/Connection.js:454:10)
   at Connection.query (/var/task/node_modules/mysql/lib/Connection.js:196:8)
   at /var/task/dbUtils.js:26:24
   at new Promise (<anonymous>)
   at query (/var/task/dbUtils.js:25:16)
   at processTicksAndRejections (internal/process/task_queues.js:95:5) {
 library: 'SSL routines',
 function: 'ssl_choose_client_version',
 reason: 'unsupported protocol',
 code: 'HANDSHAKE_SSL_ERROR',
 fatal: true
}
END RequestId: 
```

Description of changes:
Aurora engine to aurora-mysql which will update engine version to 5.7.mysql_aurora.2.xx.x)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
