### PR TITLE
fix for db cluster

### DIFF
--- a/src/init/init-template.yml
+++ b/src/init/init-template.yml
@@ -198,8 +198,8 @@ Resources:
   AuroraDBInstance:
     Type: AWS::RDS::DBInstance
     Properties:
-      DBInstanceClass: db.t2.small
-      Engine: aurora
+      DBInstanceClass: db.t3.small
+      Engine: aurora-mysql
       DBClusterIdentifier: !Ref AuroraDBCluster
 
   AuroraDBCluster:
@@ -209,7 +209,7 @@ Resources:
     Properties:
       MasterUsername: admin
       MasterUserPassword: !Ref DbPassword
-      Engine: aurora
+      Engine: aurora-mysql
       DBSubnetGroupName: !Ref AuroraSubnetGroup
       VpcSecurityGroupIds:
         - !Ref AuroraSecurityGroup 


### PR DESCRIPTION
Fix for instances cannot be added to Aurora Serverless clusters. db.t2.small not available any more.
engine: aurora tries to create serverless aurora that intances cannot be joined.

*Issue 51*