### PR TITLE
Fix Cloud9 CloudFormation stack

### DIFF
--- a/src/init/init-template.yml
+++ b/src/init/init-template.yml
@@ -138,6 +138,7 @@ Resources:
       Description: Use Cloud 9 as the default environment to launch your operations.
       InstanceType: t2.micro
       Name: Secure-Serverless-Cloud9
+      ImageId : "amazonlinux-2023-x86_64"
       SubnetId: !Ref PublicSubnet1
   
   DeploymentsS3Bucket:


### PR DESCRIPTION
*Issue #62 *

*Description of changes:*
Add ImageId in CloudFormation template for Cloud9 environment. This new parameter is required since December 4th 2023 (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloud9-environmentec2.html#cfn-cloud9-environmentec2-imageid)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
